### PR TITLE
Merge RedFantom/master into master to fix Button style

### DIFF
--- a/breeze.tcl
+++ b/breeze.tcl
@@ -112,10 +112,10 @@ namespace eval ttk::theme::Breeze {
         #
 
         ttk::style element create Button.button image [list $I(button) \
-                pressed     $I(button-active) \
+                pressed     $I(button-focus) \
                 {active focus}       $I(button-active) \
                 active      $I(button-hover) \
-                focus       $I(button-focus) \
+                focus       $I(button-hover) \
                 disabled    $I(button-insensitive) \
             ] -border 3 -sticky ewns
 


### PR DESCRIPTION
The Button style is incorrect. After the Button is pressed (and thus focused), it looks like it was pressed, while it does not look like it is pressed while it is pressed, it looks like it is being hovered over. This commit fixes this issue by changing the style of the Button.

If you would like an example of this behaviour, feel free to use the [`ttkthemes branch`](https://github.com/TkinterEP/ttkthemes/pull/63) example on which the theme is now present. If you undo the last commit, you will be able to see the behaviour. Taking screenshots is not quite clear, but I have done so anyway:
![breeze](https://user-images.githubusercontent.com/15170036/70380419-9dd57b80-193b-11ea-93b5-f99b0a3d41bd.png) ![breeze](https://user-images.githubusercontent.com/15170036/70380425-ac239780-193b-11ea-811c-a0defba9677e.png)
The left one is before, the right one is after. The cursor is not on the button in either picture (though it is in the window, it is excluded from the screenshot). In both images, the button has been pressed and is thus in focus, though it is no longer being pressed.

